### PR TITLE
Update index.ctp

### DIFF
--- a/src/Template/Bake/Template/index.ctp
+++ b/src/Template/Bake/Template/index.ctp
@@ -23,7 +23,7 @@ use Cake\Utility\Inflector;
 
 <div class="<%= $pluralVar %> index">
 	
-	<h2><?= ___('<%= strtolower($pluralHumanName) %>'); ?></h2>
+	<h2><?= __('<%= strtolower($pluralHumanName) %>'); ?></h2>
 	
 	<div class="panel panel-default">
 		<div class="panel-heading">


### PR DESCRIPTION
Global functions include a **() but not a ___() which was throwing exceptions in Cake 3. http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#**
