### PR TITLE
Update form.ctp

### DIFF
--- a/src/Template/Bake/Element/form.ctp
+++ b/src/Template/Bake/Element/form.ctp
@@ -23,7 +23,7 @@ $fields = collection($fields)
 <div class="<%= $pluralVar %> form">
 	
 	<fieldset>
-		<legend><?= ___('<%= strtolower(Inflector::humanize($action)) %> <%= strtolower($singularHumanName) %>') ?></legend>
+		<legend><?= __('<%= strtolower(Inflector::humanize($action)) %> <%= strtolower($singularHumanName) %>') ?></legend>
 		
 		<div class="panel panel-default">
 			<div class="panel-heading">


### PR DESCRIPTION
Global functions include a **() but not a ___() which was throwing exceptions in Cake 3. http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#**
